### PR TITLE
Add attendance charts and red theme to faculty dashboard

### DIFF
--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -181,7 +181,7 @@ function AttendanceTable({ records }: { records: AttendanceRecord[] }) {
   );
 }
 
-function FacultyCard({ faculty, open: controlledOpen, onOpenChange }: { faculty: FacultyMember; open?: boolean; onOpenChange?: (open: boolean) => void }) {
+function FacultyCard({ faculty, open: controlledOpen, onOpenChange, showToggle = true }: { faculty: FacultyMember; open?: boolean; onOpenChange?: (open: boolean) => void; showToggle?: boolean }) {
   const [internalOpen, setInternalOpen] = useState(false);
   const open = controlledOpen ?? internalOpen;
   const toggle = () => {
@@ -215,23 +215,25 @@ function FacultyCard({ faculty, open: controlledOpen, onOpenChange }: { faculty:
               </Pill>
             </div>
           </div>
-          <Button
-            variant="secondary"
-            size="icon"
-            aria-expanded={open}
-            aria-label={open ? "Hide attendance" : "Show attendance"}
-            onClick={toggle}
-            className={cn(
-              "shrink-0 rounded-full bg-gradient-to-br from-violet-500/10 to-indigo-500/10 hover:from-violet-500/20 hover:to-indigo-500/20 border-0",
-            )}
-          >
-            <Plus
+          {showToggle && (
+            <Button
+              variant="secondary"
+              size="icon"
+              aria-expanded={open}
+              aria-label={open ? "Hide attendance" : "Show attendance"}
+              onClick={toggle}
               className={cn(
-                "h-5 w-5 text-indigo-600 transition-transform",
-                open && "rotate-45",
+                "shrink-0 rounded-full bg-gradient-to-br from-violet-500/10 to-indigo-500/10 hover:from-violet-500/20 hover:to-indigo-500/20 border-0",
               )}
-            />
-          </Button>
+            >
+              <Plus
+                className={cn(
+                  "h-5 w-5 text-indigo-600 transition-transform",
+                  open && "rotate-45",
+                )}
+              />
+            </Button>
+          )}
         </div>
         {open && (
           <div className="mt-4 space-y-3">
@@ -249,7 +251,6 @@ function FacultyCard({ faculty, open: controlledOpen, onOpenChange }: { faculty:
 
 function HODCard({ hod }: { hod: HOD }) {
   const [open, setOpen] = useState(false);
-  const [openFacultyId, setOpenFacultyId] = useState<string | null>(null);
   return (
     <Card className="overflow-hidden">
       <CardContent className="p-4">
@@ -271,11 +272,7 @@ function HODCard({ hod }: { hod: HOD }) {
             size="icon"
             aria-expanded={open}
             aria-label={open ? "Hide faculty" : "Show faculty"}
-            onClick={() => setOpen((v) => {
-              const nv = !v;
-              if (!nv) setOpenFacultyId(null);
-              return nv;
-            })}
+            onClick={() => setOpen((v) => !v)}
             className="rounded-full bg-gradient-to-br from-violet-500/10 to-indigo-500/10 border-0"
           >
             <Plus
@@ -291,15 +288,15 @@ function HODCard({ hod }: { hod: HOD }) {
             <SectionHeader
               icon={UserRound}
               title="Faculty"
-              subtitle="Tap + to view attendance details"
+              subtitle="All faculty expanded"
             />
             <div className="flex flex-col gap-4">
               {hod.faculties.map((f) => (
                 <FacultyCard
                   key={f.id}
                   faculty={f}
-                  open={openFacultyId === f.id}
-                  onOpenChange={(next) => setOpenFacultyId(next ? f.id : null)}
+                  open={true}
+                  showToggle={false}
                 />
               ))}
             </div>

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -126,7 +126,7 @@ function SectionHeader({
   return (
     <div className="flex items-end justify-between mb-4">
       <div className="flex items-center gap-3">
-        <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-violet-500 to-indigo-500 text-white flex items-center justify-center shadow-md">
+        <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-red-500 to-rose-500 text-white flex items-center justify-center shadow-md">
           <Icon className="h-5 w-5" />
         </div>
         <div>
@@ -228,7 +228,7 @@ function FacultyCard({ faculty, open: controlledOpen, onOpenChange, showToggle =
         <div className="flex items-start justify-between gap-3">
           <div>
             <div className="flex items-center gap-2">
-              <UserRound className="h-4 w-4 text-indigo-500" />
+              <UserRound className="h-4 w-4 text-red-500" />
               <h4 className="font-medium leading-tight">{faculty.name}</h4>
             </div>
             <p className="text-xs text-muted-foreground mt-1">{faculty.role}</p>
@@ -249,12 +249,12 @@ function FacultyCard({ faculty, open: controlledOpen, onOpenChange, showToggle =
               aria-label={open ? "Hide attendance" : "Show attendance"}
               onClick={toggle}
               className={cn(
-                "shrink-0 rounded-full bg-gradient-to-br from-violet-500/10 to-indigo-500/10 hover:from-violet-500/20 hover:to-indigo-500/20 border-0",
+                "shrink-0 rounded-full bg-gradient-to-br from-red-500/10 to-rose-500/10 hover:from-red-500/20 hover:to-rose-500/20 border-0",
               )}
             >
               <Plus
                 className={cn(
-                  "h-5 w-5 text-indigo-600 transition-transform",
+                  "h-5 w-5 text-red-600 transition-transform",
                   open && "rotate-45",
                 )}
               />
@@ -346,7 +346,7 @@ function HODCard({ hod }: { hod: HOD }) {
       <CardContent className="p-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Users className="h-4 w-4 text-indigo-500" />
+            <Users className="h-4 w-4 text-red-500" />
             <div>
               <h4 className="font-medium leading-tight">{hod.name}</h4>
               <p className="text-xs text-muted-foreground">
@@ -367,11 +367,11 @@ function HODCard({ hod }: { hod: HOD }) {
               if (!nv) setOpenFacultyId(null);
               return nv;
             })}
-            className="rounded-full bg-gradient-to-br from-violet-500/10 to-indigo-500/10 border-0"
+            className="rounded-full bg-gradient-to-br from-red-500/10 to-rose-500/10 border-0"
           >
             <Plus
               className={cn(
-                "h-5 w-5 text-indigo-600 transition-transform",
+                "h-5 w-5 text-red-600 transition-transform",
                 open && "rotate-45",
               )}
             />
@@ -490,13 +490,13 @@ function DepartmentCard({
     <Card
       className={cn(
         "overflow-hidden",
-        selected && "ring-2 ring-indigo-200 border-indigo-200",
+        selected && "ring-2 ring-red-200 border-red-200",
       )}
     >
       <CardContent className="p-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-indigo-500 to-violet-500 text-white grid place-items-center">
+            <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-red-500 to-rose-500 text-white grid place-items-center">
               <Building2 className="h-5 w-5" />
             </div>
             <div>
@@ -513,11 +513,11 @@ function DepartmentCard({
             aria-expanded={isOpen}
             aria-label={isOpen ? "Hide HOD" : "Show HOD"}
             onClick={toggle}
-            className="rounded-full bg-gradient-to-br from-violet-500/10 to-indigo-500/10 border-0"
+            className="rounded-full bg-gradient-to-br from-red-500/10 to-rose-500/10 border-0"
           >
             <Plus
               className={cn(
-                "h-5 w-5 text-indigo-600 transition-transform",
+                "h-5 w-5 text-red-600 transition-transform",
                 isOpen && "rotate-45",
               )}
             />

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -177,8 +177,13 @@ function AttendanceTable({ records }: { records: AttendanceRecord[] }) {
   );
 }
 
-function FacultyCard({ faculty }: { faculty: FacultyMember }) {
-  const [open, setOpen] = useState(false);
+function FacultyCard({ faculty, open: controlledOpen, onOpenChange }: { faculty: FacultyMember; open?: boolean; onOpenChange?: (open: boolean) => void }) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const toggle = () => {
+    if (onOpenChange) onOpenChange(!open);
+    else setInternalOpen((v) => !v);
+  };
   const presentCount = useMemo(
     () => faculty.attendance.filter((a) => a.status === "Present").length,
     [faculty],
@@ -211,7 +216,7 @@ function FacultyCard({ faculty }: { faculty: FacultyMember }) {
             size="icon"
             aria-expanded={open}
             aria-label={open ? "Hide attendance" : "Show attendance"}
-            onClick={() => setOpen((v) => !v)}
+            onClick={toggle}
             className={cn(
               "shrink-0 rounded-full bg-gradient-to-br from-violet-500/10 to-indigo-500/10 hover:from-violet-500/20 hover:to-indigo-500/20 border-0",
             )}
@@ -240,6 +245,7 @@ function FacultyCard({ faculty }: { faculty: FacultyMember }) {
 
 function HODCard({ hod }: { hod: HOD }) {
   const [open, setOpen] = useState(false);
+  const [openFacultyId, setOpenFacultyId] = useState<string | null>(null);
   return (
     <Card className="overflow-hidden">
       <CardContent className="p-4">
@@ -261,7 +267,11 @@ function HODCard({ hod }: { hod: HOD }) {
             size="icon"
             aria-expanded={open}
             aria-label={open ? "Hide faculty" : "Show faculty"}
-            onClick={() => setOpen((v) => !v)}
+            onClick={() => setOpen((v) => {
+              const nv = !v;
+              if (!nv) setOpenFacultyId(null);
+              return nv;
+            })}
             className="rounded-full bg-gradient-to-br from-violet-500/10 to-indigo-500/10 border-0"
           >
             <Plus
@@ -281,7 +291,12 @@ function HODCard({ hod }: { hod: HOD }) {
             />
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {hod.faculties.map((f) => (
-                <FacultyCard key={f.id} faculty={f} />
+                <FacultyCard
+                  key={f.id}
+                  faculty={f}
+                  open={openFacultyId === f.id}
+                  onOpenChange={(next) => setOpenFacultyId(next ? f.id : null)}
+                />
               ))}
             </div>
           </div>

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 
 // Data types
@@ -58,6 +59,9 @@ function generateAttendance(days = 14): AttendanceRecord[] {
 function sampleData(): Department[] {
   const depts = [
     { id: "cse", name: "Computer Science & Engineering", code: "CSE" },
+    { id: "ece", name: "Electronics & Communication Engineering", code: "ECE" },
+    { id: "me", name: "Mechanical Engineering", code: "ME" },
+    { id: "ce", name: "Civil Engineering", code: "CE" },
   ];
 
   return depts.map((d, idx) => {
@@ -382,6 +386,11 @@ function DepartmentCard({
 
 export default function PrincipalDashboard() {
   const departments = useMemo(() => sampleData(), []);
+  const [selectedDept, setSelectedDept] = useState<string>("all");
+  const filteredDepartments = useMemo(
+    () => (selectedDept === "all" ? departments : departments.filter((d) => d.id === selectedDept)),
+    [departments, selectedDept],
+  );
 
   return (
     <div className="space-y-8">
@@ -427,16 +436,32 @@ export default function PrincipalDashboard() {
         </Card>
       </div>
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
         <SectionHeader
           icon={Building2}
           title="Departments"
           subtitle="Tap + on a department to view HOD"
         />
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Filter</span>
+          <Select value={selectedDept} onValueChange={setSelectedDept}>
+            <SelectTrigger className="w-60">
+              <SelectValue placeholder="Select department" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Departments</SelectItem>
+              {departments.map((d) => (
+                <SelectItem key={d.id} value={d.id}>
+                  {d.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 gap-6">
-        {departments.map((dept) => (
+        {filteredDepartments.map((dept) => (
           <DepartmentCard key={dept.id} dept={dept} defaultOpen selected />
         ))}
       </div>

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -289,7 +289,7 @@ function HODCard({ hod }: { hod: HOD }) {
               title="Faculty"
               subtitle="Tap + to view attendance details"
             />
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="flex flex-col gap-4">
               {hod.faculties.map((f) => (
                 <FacultyCard
                   key={f.id}

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -295,7 +295,7 @@ function HODCard({ hod }: { hod: HOD }) {
               title="Faculty"
               subtitle="Tap + to view attendance details"
             />
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="flex flex-col gap-4">
               {hod.faculties.map((f) => (
                 <FacultyCard
                   key={f.id}

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -353,7 +353,7 @@ function DepartmentCard({
               title="Heads of Department"
               subtitle="Tap + to view faculty"
             />
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="flex flex-col gap-4">
               {dept.hods.map((h) => (
                 <HODCard key={h.id} hod={h} />
               ))}

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { ResponsiveContainer, PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts";
 
 // Data types
 export interface AttendanceRecord {
@@ -196,6 +197,31 @@ function FacultyCard({ faculty, open: controlledOpen, onOpenChange, showToggle =
     () => faculty.attendance.filter((a) => a.status === "Absent").length,
     [faculty],
   );
+  const leaveCount = useMemo(
+    () => faculty.attendance.filter((a) => a.status === "On Leave").length,
+    [faculty],
+  );
+  const pieData = useMemo(
+    () => [
+      { name: "Present", value: presentCount },
+      { name: "Absent", value: absentCount },
+      { name: "On Leave", value: leaveCount },
+    ],
+    [presentCount, absentCount, leaveCount],
+  );
+  const barData = useMemo(
+    () =>
+      faculty.attendance
+        .slice()
+        .reverse()
+        .map((r) => ({
+          d: r.date.slice(5),
+          Present: r.status === "Present" ? 1 : 0,
+          Absent: r.status === "Absent" ? 1 : 0,
+          OnLeave: r.status === "On Leave" ? 1 : 0,
+        })),
+    [faculty],
+  );
   return (
     <Card className="group overflow-hidden">
       <CardContent className="p-4">
@@ -236,7 +262,41 @@ function FacultyCard({ faculty, open: controlledOpen, onOpenChange, showToggle =
           )}
         </div>
         {open && (
-          <div className="mt-4 space-y-3">
+          <div className="mt-4 space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="rounded-lg border bg-card p-3">
+                <h5 className="text-sm font-medium mb-2">Attendance Breakdown</h5>
+                <div className="h-48">
+                  <ResponsiveContainer>
+                    <PieChart>
+                      <Pie data={pieData} dataKey="value" nameKey="name" innerRadius={40} outerRadius={70} paddingAngle={2}>
+                        <Cell fill="#10B981" />
+                        <Cell fill="#EF4444" />
+                        <Cell fill="#F59E0B" />
+                      </Pie>
+                      <Legend verticalAlign="bottom" height={24} />
+                      <Tooltip />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+              <div className="rounded-lg border bg-card p-3">
+                <h5 className="text-sm font-medium mb-2">Last 14 days</h5>
+                <div className="h-48">
+                  <ResponsiveContainer>
+                    <BarChart data={barData}>
+                      <XAxis dataKey="d" tick={{ fontSize: 10 }} />
+                      <YAxis allowDecimals={false} tick={{ fontSize: 10 }} />
+                      <Tooltip />
+                      <Legend />
+                      <Bar dataKey="Present" stackId="a" fill="#10B981" name="Present" />
+                      <Bar dataKey="Absent" stackId="a" fill="#EF4444" name="Absent" />
+                      <Bar dataKey="OnLeave" stackId="a" fill="#F59E0B" name="On Leave" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+            </div>
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <CalendarDays className="h-4 w-4" />
               Last 14 days

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -11,9 +11,26 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import { ResponsiveContainer, PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts";
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+} from "recharts";
 
 // Data types
 export interface AttendanceRecord {
@@ -182,7 +199,17 @@ function AttendanceTable({ records }: { records: AttendanceRecord[] }) {
   );
 }
 
-function FacultyCard({ faculty, open: controlledOpen, onOpenChange, showToggle = true }: { faculty: FacultyMember; open?: boolean; onOpenChange?: (open: boolean) => void; showToggle?: boolean }) {
+function FacultyCard({
+  faculty,
+  open: controlledOpen,
+  onOpenChange,
+  showToggle = true,
+}: {
+  faculty: FacultyMember;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  showToggle?: boolean;
+}) {
   const [internalOpen, setInternalOpen] = useState(false);
   const open = controlledOpen ?? internalOpen;
   const toggle = () => {
@@ -265,11 +292,20 @@ function FacultyCard({ faculty, open: controlledOpen, onOpenChange, showToggle =
           <div className="mt-4 space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="rounded-lg border bg-card p-3">
-                <h5 className="text-sm font-medium mb-2">Attendance Breakdown</h5>
+                <h5 className="text-sm font-medium mb-2">
+                  Attendance Breakdown
+                </h5>
                 <div className="h-48">
                   <ResponsiveContainer>
                     <PieChart>
-                      <Pie data={pieData} dataKey="value" nameKey="name" innerRadius={40} outerRadius={70} paddingAngle={2}>
+                      <Pie
+                        data={pieData}
+                        dataKey="value"
+                        nameKey="name"
+                        innerRadius={40}
+                        outerRadius={70}
+                        paddingAngle={2}
+                      >
                         <Cell fill="#10B981" />
                         <Cell fill="#EF4444" />
                         <Cell fill="#F59E0B" />
@@ -289,9 +325,24 @@ function FacultyCard({ faculty, open: controlledOpen, onOpenChange, showToggle =
                       <YAxis allowDecimals={false} tick={{ fontSize: 10 }} />
                       <Tooltip />
                       <Legend />
-                      <Bar dataKey="Present" stackId="a" fill="#10B981" name="Present" />
-                      <Bar dataKey="Absent" stackId="a" fill="#EF4444" name="Absent" />
-                      <Bar dataKey="OnLeave" stackId="a" fill="#F59E0B" name="On Leave" />
+                      <Bar
+                        dataKey="Present"
+                        stackId="a"
+                        fill="#10B981"
+                        name="Present"
+                      />
+                      <Bar
+                        dataKey="Absent"
+                        stackId="a"
+                        fill="#EF4444"
+                        name="Absent"
+                      />
+                      <Bar
+                        dataKey="OnLeave"
+                        stackId="a"
+                        fill="#F59E0B"
+                        name="On Leave"
+                      />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
@@ -327,10 +378,17 @@ function HODCard({ hod }: { hod: HOD }) {
     ];
   }, [hod]);
   const hodBarData = useMemo(() => {
-    const byDate = new Map<string, { Present: number; Absent: number; OnLeave: number }>();
+    const byDate = new Map<
+      string,
+      { Present: number; Absent: number; OnLeave: number }
+    >();
     for (const f of hod.faculties) {
       for (const r of f.attendance) {
-        const entry = byDate.get(r.date) ?? { Present: 0, Absent: 0, OnLeave: 0 };
+        const entry = byDate.get(r.date) ?? {
+          Present: 0,
+          Absent: 0,
+          OnLeave: 0,
+        };
         if (r.status === "Present") entry.Present += 1;
         else if (r.status === "Absent") entry.Absent += 1;
         else entry.OnLeave += 1;
@@ -362,11 +420,13 @@ function HODCard({ hod }: { hod: HOD }) {
             size="icon"
             aria-expanded={open}
             aria-label={open ? "Hide faculty" : "Show faculty"}
-            onClick={() => setOpen((v) => {
-              const nv = !v;
-              if (!nv) setOpenFacultyId(null);
-              return nv;
-            })}
+            onClick={() =>
+              setOpen((v) => {
+                const nv = !v;
+                if (!nv) setOpenFacultyId(null);
+                return nv;
+              })
+            }
             className="rounded-full bg-gradient-to-br from-red-500/10 to-rose-500/10 border-0"
           >
             <Plus
@@ -381,11 +441,20 @@ function HODCard({ hod }: { hod: HOD }) {
           <div className="mt-4 space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="rounded-lg border bg-card p-3">
-                <h5 className="text-sm font-medium mb-2">HOD Attendance Breakdown</h5>
+                <h5 className="text-sm font-medium mb-2">
+                  HOD Attendance Breakdown
+                </h5>
                 <div className="h-48">
                   <ResponsiveContainer>
                     <PieChart>
-                      <Pie data={hodPieData} dataKey="value" nameKey="name" innerRadius={40} outerRadius={70} paddingAngle={2}>
+                      <Pie
+                        data={hodPieData}
+                        dataKey="value"
+                        nameKey="name"
+                        innerRadius={40}
+                        outerRadius={70}
+                        paddingAngle={2}
+                      >
                         <Cell fill="#10B981" />
                         <Cell fill="#EF4444" />
                         <Cell fill="#F59E0B" />
@@ -397,7 +466,9 @@ function HODCard({ hod }: { hod: HOD }) {
                 </div>
               </div>
               <div className="rounded-lg border bg-card p-3">
-                <h5 className="text-sm font-medium mb-2">Last 14 days (All Faculty)</h5>
+                <h5 className="text-sm font-medium mb-2">
+                  Last 14 days (All Faculty)
+                </h5>
                 <div className="h-48">
                   <ResponsiveContainer>
                     <BarChart data={hodBarData}>
@@ -405,9 +476,24 @@ function HODCard({ hod }: { hod: HOD }) {
                       <YAxis allowDecimals={false} tick={{ fontSize: 10 }} />
                       <Tooltip />
                       <Legend />
-                      <Bar dataKey="Present" stackId="a" fill="#10B981" name="Present" />
-                      <Bar dataKey="Absent" stackId="a" fill="#EF4444" name="Absent" />
-                      <Bar dataKey="OnLeave" stackId="a" fill="#F59E0B" name="On Leave" />
+                      <Bar
+                        dataKey="Present"
+                        stackId="a"
+                        fill="#10B981"
+                        name="Present"
+                      />
+                      <Bar
+                        dataKey="Absent"
+                        stackId="a"
+                        fill="#EF4444"
+                        name="Absent"
+                      />
+                      <Bar
+                        dataKey="OnLeave"
+                        stackId="a"
+                        fill="#F59E0B"
+                        name="On Leave"
+                      />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
@@ -454,7 +540,9 @@ function DepartmentCard({
     onOpenChange ? onOpenChange(!isOpen) : setInternalOpen((v) => !v);
 
   const deptPieData = useMemo(() => {
-    const all = dept.hods.flatMap((h) => h.faculties.flatMap((f) => f.attendance));
+    const all = dept.hods.flatMap((h) =>
+      h.faculties.flatMap((f) => f.attendance),
+    );
     const counts = { Present: 0, Absent: 0, OnLeave: 0 };
     for (const r of all) {
       if (r.status === "Present") counts.Present++;
@@ -469,11 +557,18 @@ function DepartmentCard({
   }, [dept]);
 
   const deptBarData = useMemo(() => {
-    const byDate = new Map<string, { Present: number; Absent: number; OnLeave: number }>();
+    const byDate = new Map<
+      string,
+      { Present: number; Absent: number; OnLeave: number }
+    >();
     for (const h of dept.hods) {
       for (const f of h.faculties) {
         for (const r of f.attendance) {
-          const entry = byDate.get(r.date) ?? { Present: 0, Absent: 0, OnLeave: 0 };
+          const entry = byDate.get(r.date) ?? {
+            Present: 0,
+            Absent: 0,
+            OnLeave: 0,
+          };
           if (r.status === "Present") entry.Present += 1;
           else if (r.status === "Absent") entry.Absent += 1;
           else entry.OnLeave += 1;
@@ -527,11 +622,20 @@ function DepartmentCard({
           <div className="mt-5 space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="rounded-lg border bg-card p-3">
-                <h5 className="text-sm font-medium mb-2">Department Attendance Breakdown</h5>
+                <h5 className="text-sm font-medium mb-2">
+                  Department Attendance Breakdown
+                </h5>
                 <div className="h-48">
                   <ResponsiveContainer>
                     <PieChart>
-                      <Pie data={deptPieData} dataKey="value" nameKey="name" innerRadius={40} outerRadius={70} paddingAngle={2}>
+                      <Pie
+                        data={deptPieData}
+                        dataKey="value"
+                        nameKey="name"
+                        innerRadius={40}
+                        outerRadius={70}
+                        paddingAngle={2}
+                      >
                         <Cell fill="#10B981" />
                         <Cell fill="#EF4444" />
                         <Cell fill="#F59E0B" />
@@ -543,7 +647,9 @@ function DepartmentCard({
                 </div>
               </div>
               <div className="rounded-lg border bg-card p-3">
-                <h5 className="text-sm font-medium mb-2">Last 14 days (All HODs)</h5>
+                <h5 className="text-sm font-medium mb-2">
+                  Last 14 days (All HODs)
+                </h5>
                 <div className="h-48">
                   <ResponsiveContainer>
                     <BarChart data={deptBarData}>
@@ -551,9 +657,24 @@ function DepartmentCard({
                       <YAxis allowDecimals={false} tick={{ fontSize: 10 }} />
                       <Tooltip />
                       <Legend />
-                      <Bar dataKey="Present" stackId="a" fill="#10B981" name="Present" />
-                      <Bar dataKey="Absent" stackId="a" fill="#EF4444" name="Absent" />
-                      <Bar dataKey="OnLeave" stackId="a" fill="#F59E0B" name="On Leave" />
+                      <Bar
+                        dataKey="Present"
+                        stackId="a"
+                        fill="#10B981"
+                        name="Present"
+                      />
+                      <Bar
+                        dataKey="Absent"
+                        stackId="a"
+                        fill="#EF4444"
+                        name="Absent"
+                      />
+                      <Bar
+                        dataKey="OnLeave"
+                        stackId="a"
+                        fill="#F59E0B"
+                        name="On Leave"
+                      />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
@@ -578,7 +699,9 @@ function DepartmentCard({
 
 export default function PrincipalDashboard() {
   const departments = useMemo(() => sampleData(), []);
-  const [selectedDept, setSelectedDept] = useState<string>(departments[0]?.id ?? "");
+  const [selectedDept, setSelectedDept] = useState<string>(
+    departments[0]?.id ?? "",
+  );
   const filteredDepartments = useMemo(
     () => departments.filter((d) => d.id === selectedDept),
     [departments, selectedDept],

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -290,7 +290,7 @@ function HODCard({ hod }: { hod: HOD }) {
               title="Faculty"
               subtitle="All faculty expanded"
             />
-            <div className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {hod.faculties.map((f) => (
                 <FacultyCard
                   key={f.id}

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -251,6 +251,7 @@ function FacultyCard({ faculty, open: controlledOpen, onOpenChange, showToggle =
 
 function HODCard({ hod }: { hod: HOD }) {
   const [open, setOpen] = useState(false);
+  const [openFacultyId, setOpenFacultyId] = useState<string | null>(null);
   return (
     <Card className="overflow-hidden">
       <CardContent className="p-4">
@@ -272,7 +273,11 @@ function HODCard({ hod }: { hod: HOD }) {
             size="icon"
             aria-expanded={open}
             aria-label={open ? "Hide faculty" : "Show faculty"}
-            onClick={() => setOpen((v) => !v)}
+            onClick={() => setOpen((v) => {
+              const nv = !v;
+              if (!nv) setOpenFacultyId(null);
+              return nv;
+            })}
             className="rounded-full bg-gradient-to-br from-violet-500/10 to-indigo-500/10 border-0"
           >
             <Plus
@@ -288,15 +293,15 @@ function HODCard({ hod }: { hod: HOD }) {
             <SectionHeader
               icon={UserRound}
               title="Faculty"
-              subtitle="All faculty expanded"
+              subtitle="Tap + to view attendance details"
             />
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {hod.faculties.map((f) => (
                 <FacultyCard
                   key={f.id}
                   faculty={f}
-                  open={true}
-                  showToggle={false}
+                  open={openFacultyId === f.id}
+                  onOpenChange={(next) => setOpenFacultyId(next ? f.id : null)}
                 />
               ))}
             </div>

--- a/client/components/dashboard/PrincipalDashboard.tsx
+++ b/client/components/dashboard/PrincipalDashboard.tsx
@@ -386,9 +386,9 @@ function DepartmentCard({
 
 export default function PrincipalDashboard() {
   const departments = useMemo(() => sampleData(), []);
-  const [selectedDept, setSelectedDept] = useState<string>("all");
+  const [selectedDept, setSelectedDept] = useState<string>(departments[0]?.id ?? "");
   const filteredDepartments = useMemo(
-    () => (selectedDept === "all" ? departments : departments.filter((d) => d.id === selectedDept)),
+    () => departments.filter((d) => d.id === selectedDept),
     [departments, selectedDept],
   );
 
@@ -449,7 +449,6 @@ export default function PrincipalDashboard() {
               <SelectValue placeholder="Select department" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">All Departments</SelectItem>
               {departments.map((d) => (
                 <SelectItem key={d.id} value={d.id}>
                   {d.name}

--- a/client/components/layout/AppLayout.tsx
+++ b/client/components/layout/AppLayout.tsx
@@ -11,7 +11,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       <header className="sticky top-0 z-40 w-full backdrop-blur supports-[backdrop-filter]:bg-white/70 border-b">
         <div className="container flex items-center justify-between h-16">
           <div className="flex items-center gap-3">
-            <div className="h-9 w-9 rounded-xl bg-gradient-to-br from-violet-500 to-indigo-500 shadow-lg shadow-indigo-200" />
+            <div className="h-9 w-9 rounded-xl bg-gradient-to-br from-red-500 to-rose-500 shadow-lg shadow-red-200" />
             <div>
               <p className="text-sm text-muted-foreground leading-none">
                 Principal

--- a/client/global.css
+++ b/client/global.css
@@ -21,7 +21,7 @@
     --popover: 0 0% 100%;
     --popover-foreground: 230 47% 12%;
 
-    --primary: 258 90% 55%;
+    --primary: 0 72% 50%;
     --primary-foreground: 0 0% 100%;
 
     --secondary: 220 14% 96%;
@@ -30,26 +30,26 @@
     --muted: 220 14% 96%;
     --muted-foreground: 220 10% 46%;
 
-    --accent: 258 90% 96%;
-    --accent-foreground: 260 58% 32%;
+    --accent: 0 90% 96%;
+    --accent-foreground: 0 60% 35%;
 
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;
 
     --border: 220 18% 90%;
     --input: 220 18% 90%;
-    --ring: 258 90% 45%;
+    --ring: 0 72% 50%;
 
     --radius: 0.75rem;
 
     --sidebar-background: 220 23% 99%;
     --sidebar-foreground: 230 47% 12%;
-    --sidebar-primary: 258 90% 55%;
+    --sidebar-primary: 0 72% 50%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 258 90% 96%;
-    --sidebar-accent-foreground: 260 58% 32%;
+    --sidebar-accent: 0 90% 96%;
+    --sidebar-accent-foreground: 0 60% 35%;
     --sidebar-border: 220 18% 90%;
-    --sidebar-ring: 258 90% 45%;
+    --sidebar-ring: 0 72% 50%;
   }
 
   .dark {
@@ -62,7 +62,7 @@
     --popover: 232 25% 10%;
     --popover-foreground: 210 40% 98%;
 
-    --primary: 258 90% 60%;
+    --primary: 0 84% 60%;
     --primary-foreground: 0 0% 100%;
 
     --secondary: 230 15% 16%;
@@ -71,24 +71,24 @@
     --muted: 230 15% 16%;
     --muted-foreground: 220 10% 70%;
 
-    --accent: 258 90% 20%;
-    --accent-foreground: 258 90% 90%;
+    --accent: 0 90% 20%;
+    --accent-foreground: 0 90% 90%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 230 15% 18%;
     --input: 230 15% 18%;
-    --ring: 258 90% 60%;
+    --ring: 0 84% 60%;
 
     --sidebar-background: 232 25% 8%;
     --sidebar-foreground: 210 40% 98%;
-    --sidebar-primary: 258 90% 60%;
+    --sidebar-primary: 0 84% 60%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 258 90% 20%;
-    --sidebar-accent-foreground: 258 90% 90%;
+    --sidebar-accent: 0 90% 20%;
+    --sidebar-accent-foreground: 0 90% 90%;
     --sidebar-border: 230 15% 18%;
-    --sidebar-ring: 258 90% 60%;
+    --sidebar-ring: 0 84% 60%;
   }
 }
 

--- a/client/pages/NotFound.tsx
+++ b/client/pages/NotFound.tsx
@@ -20,7 +20,7 @@ const NotFound = () => {
         </p>
         <a
           href="/"
-          className="text-indigo-600 hover:text-indigo-700 underline font-medium"
+          className="text-red-600 hover:text-red-700 underline font-medium"
         >
           Return to Home
         </a>


### PR DESCRIPTION
## Purpose
Based on the conversation history, the user requested several enhancements to the faculty dashboard:
- Add a plus button for HOD faculty grid to expand and show all faculty members
- Make faculty layout horizontally long
- Add attendance pie charts and bar charts to visualize attendance data
- Apply a red theme throughout the application

## Code changes
- **Charts Integration**: Added Recharts library components (PieChart, BarChart) with attendance visualization
  - Pie charts showing attendance breakdown (Present/Absent/On Leave) for individual faculty and departments
  - Bar charts displaying last 14 days attendance trends
- **Theme Update**: Changed color scheme from violet/indigo to red/rose throughout the application
  - Updated gradients, borders, and accent colors in components and CSS variables
  - Modified primary colors in both light and dark themes
- **Layout Improvements**: Enhanced faculty card layout with expandable sections and better organization
- **Department Filter**: Added dropdown selector to filter departments in the principal dashboard
- **Faculty Grid Enhancement**: Improved HOD faculty display with controlled expand/collapse functionalityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4895309edcdc46a5ac041d6bdd6411c8/zenith-nest)

👀 [Preview Link](https://4895309edcdc46a5ac041d6bdd6411c8-zenith-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4895309edcdc46a5ac041d6bdd6411c8</projectId>-->
<!--<branchName>zenith-nest</branchName>-->